### PR TITLE
Replaced worksheet names with hard-coded values instead of being derived...

### DIFF
--- a/trelloexport.js
+++ b/trelloexport.js
@@ -69,7 +69,7 @@ function createExcelExport() {
             
             // Setup the active list and cart worksheet
             w = file.worksheets[0]; 
-            w.name = data.name;
+            w.name = 'Current';
             w.data = [];
             w.data.push([]);
             w.data[0] = columnHeadings;
@@ -77,7 +77,7 @@ function createExcelExport() {
             
             // Setup the archive list and cart worksheet            
             wArchived = file.worksheets[1]; 
-            wArchived.name = 'Archived ' + data.name;
+            wArchived.name = 'Archived';
             wArchived.data = [];
             wArchived.data.push([]);
             wArchived.data[0] = columnHeadings;


### PR DESCRIPTION
... from board name

The board name was being used in the worksheet name, but due to Excel limits (and the use of the 'Archived ' prefix on one tab), that limited the board name length to only 22 characters.  Since the file name is the board name already, the board name doesn't need to be duplicated in the tabs - just have a 'Current' tab and an 'Archived' one.
