### PR TITLE
Used Trello API to get data instead of JSON export.

### DIFF
--- a/trelloexport.js
+++ b/trelloexport.js
@@ -30,7 +30,19 @@ function createExcelExport() {
     // RegEx to find the points for users of TrelloScrum
     var pointReg = /[\(](\x3f|\d*\.?\d+)([\)])\s?/m;
 
-    $.getJSON($('a.js-export-json').attr('href'), function (data) {
+	var boardExportURL = $('a.js-export-json').attr('href');
+	//RegEx to extract Board ID
+	var parts = /\/b\/(\w{8})\.json/.exec(boardExportURL);
+
+	if(!parts) {
+		alert("Board menu not open.")
+		return;
+	}
+
+	var idBoard = parts[1];
+	var apiURL = "https://trello.com/1/boards/" + idBoard + "?lists=open&cards=visible&card_attachments=cover&card_stickers=true&card_fields=badges%2Cclosed%2CdateLastActivity%2Cdesc%2CdescData%2Cdue%2CidAttachmentCover%2CidList%2CidBoard%2CidMembers%2CidShort%2Clabels%2CidLabels%2Cname%2Cpos%2CshortUrl%2CshortLink%2Csubscribed%2Curl&card_checklists=none&members=all&member_fields=fullName%2Cinitials%2CmemberType%2Cusername%2CavatarHash%2Cbio%2CbioData%2Cconfirmed%2Cproducts%2Curl%2Cstatus&membersInvited=all&membersInvited_fields=fullName%2Cinitials%2CmemberType%2Cusername%2CavatarHash%2Cbio%2CbioData%2Cconfirmed%2Cproducts%2Curl&checklists=none&organization=true&organization_fields=name%2CdisplayName%2Cdesc%2CdescData%2Curl%2Cwebsite%2Cprefs%2Cmemberships%2ClogoHash%2Cproducts&myPrefs=true&fields=name%2Cclosed%2CdateLastActivity%2CdateLastView%2CidOrganization%2Cprefs%2CshortLink%2CshortUrl%2Curl%2Cdesc%2CdescData%2Cinvitations%2Cinvited%2ClabelNames%2Cmemberships%2Cpinned%2CpowerUps%2Csubscribed"
+
+    $.getJSON(apiURL, function (data) {
             
         var file = {
             worksheets: [[], []], // worksheets has one empty worksheet (array)


### PR DESCRIPTION
Hey Mark—This is Michelle, from Trello Support. On boards with lots of checklists, the full JSON export was breaking & showing performance issues on Trello servers, so one of the Trello devs gave us this API route to use instead.
